### PR TITLE
feat: handle service status check + add colors

### DIFF
--- a/cmd/stackfetch/main.go
+++ b/cmd/stackfetch/main.go
@@ -8,133 +8,116 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/fatih/color"
 	"github.com/sanix-darker/stackfetch/internal/guess"
 	"github.com/sanix-darker/stackfetch/internal/langfetch"
+	"github.com/sanix-darker/stackfetch/internal/services"
 	"github.com/sanix-darker/stackfetch/internal/sysinfo"
 	"github.com/spf13/cobra"
 )
 
 type result struct {
-	System  sysinfo.Info       `json:"system"`
-	Reports []langfetch.Result `json:"reports"`
-	Guessed []string           `json:"guessed,omitempty"`
+	System   sysinfo.Info       `json:"system"`
+	Reports  []langfetch.Result `json:"reports"`
+	Services []services.Status  `json:"services,omitempty"`
+	Guessed  []string           `json:"guessed,omitempty"`
 }
 
 func main() {
-	var jsonOut bool
+    var jsonOut bool
 
-	root := &cobra.Command{
-		Use:   "stackfetch [items…]",
-		Short: "System / language / DevOps stack fetcher",
-		Args:  cobra.ArbitraryArgs,
-	}
+    root := &cobra.Command{
+        Use:   "stackfetch [items…]",
+        Short: "System / language / DevOps stack fetcher",
+        Args:  cobra.ArbitraryArgs,
+    }
+    root.PersistentFlags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+    root.RunE = func(cmd *cobra.Command, args []string) error {
+        return runStackfetch(jsonOut, nil, args)
+    }
 
-	root.PersistentFlags().BoolVarP(&jsonOut, "json", "j", false, "output as JSON")
+    guessCmd := &cobra.Command{
+        Use:     "guess",
+        Aliases: []string{"?"},
+        Short:   "Guess project stack based on files in cwd",
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            cwd, _ := os.Getwd()
+            guessed := guess.Guess(cwd)
+            return runStackfetch(jsonOut, guessed, guessed)
+        },
+    }
+    root.AddCommand(guessCmd)
 
-	// Default run: takes positional args
-	root.RunE = func(cmd *cobra.Command, args []string) error {
-		var jsonOut bool = jsonOut
-		res := result{System: sysinfo.Collect(), Guessed: []string(nil)}
-		res.Reports = langfetch.FetchMany(args)
-		if jsonOut {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(res)
-		}
-		fmt.Println("=== System ===")
-		fmt.Println(res.System)
-		if len([]string(nil)) > 0 {
-			fmt.Printf("\nGuessed: %s\n", filepath.Base("."))
-			fmt.Println("Detected items:", []string(nil))
-		}
-		for _, r := range res.Reports {
-			fmt.Printf("\n=== %s ===\n", r.Key)
-			if r.Err != nil {
-				fmt.Fprintln(os.Stderr, "stackfetch:", r.Err)
-				continue
-			}
-			fmt.Println(r.Info)
-		}
-		return nil
-	}
-
-	// Guess sub-command (alias “?”)
-	guessCmd := &cobra.Command{
-		Use:     "guess",
-		Aliases: []string{"?"},
-		Short:   "Guess project stack based on files in cwd",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			cwd, _ := os.Getwd()
-			guessed := guess.Guess(cwd)
-			var (
-				jsonOut bool     = jsonOut
-				args    []string = guessed
-			)
-			res := result{System: sysinfo.Collect(), Guessed: guessed}
-			res.Reports = langfetch.FetchMany(args)
-			if jsonOut {
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "  ")
-				return enc.Encode(res)
-			}
-			fmt.Println("=== System ===")
-			fmt.Println(res.System)
-			if len(guessed) > 0 {
-				fmt.Printf("\nGuessed: %s\n", filepath.Base("."))
-				fmt.Println("Detected items:", guessed)
-			}
-			for _, r := range res.Reports {
-				fmt.Printf("\n=== %s ===\n", r.Key)
-				if r.Err != nil {
-					fmt.Fprintln(os.Stderr, "stackfetch:", r.Err)
-					continue
-				}
-				fmt.Println(r.Info)
-			}
-			return nil
-		},
-	}
-	root.AddCommand(guessCmd)
-
-	if err := root.Execute(); err != nil {
-		log.Fatalf("%v", err)
-	}
-
+    if err := root.Execute(); err != nil {
+        log.Fatalf("%v", err)
+    }
 	// On Windows, pause so the console doesn’t vanish immediately
     // YES DUDE, THAT'S A THING ON WINDOWS !
-	if runtime.GOOS == "windows" {
-		fmt.Println("Press Enter to exit…")
-		fmt.Scanln()
-	}
+    if runtime.GOOS == "windows" {
+        fmt.Println("Press Enter to exit…")
+        fmt.Scanln()
+    }
 }
 
 // runStackfetch centralizes both plain-text and JSON output
 func runStackfetch(jsonOut bool, guessed, args []string) error {
-	res := result{
-		System:  sysinfo.Collect(),
-		Guessed: guessed,
-	}
-	res.Reports = langfetch.FetchMany(args)
+    res := result{
+        System:  sysinfo.Collect(),
+        Guessed: guessed,
+    }
+    // parallel fetch of all requested items
+    res.Reports = langfetch.FetchMany(args)
 
-	if jsonOut {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(res)
-	}
+    // build dependency list for all keys we care about
+    var deps []string
+    for _, key := range append(guessed, args...) {
+        deps = append(deps, langfetch.Dependencies(key)...)
+    }
+    // now check only those services/tools
+    res.Services = services.Check(deps)
 
-	fmt.Println("=== System ===")
-	fmt.Println(res.System)
-	if len(guessed) > 0 {
-		fmt.Printf("\nGuessed: %s\n", filepath.Base("."))
-		fmt.Println("Detected items:", guessed)
+    if jsonOut {
+        enc := json.NewEncoder(os.Stdout)
+        enc.SetIndent("", "  ")
+        return enc.Encode(res)
+    }
+
+    fmt.Println("=== System ===")
+    fmt.Println(res.System)
+
+    if len(guessed) > 0 {
+        fmt.Printf("\nGuessed: %s\n", filepath.Base("."))
+        fmt.Println("Detected items:", guessed)
+    }
+
+    for _, r := range res.Reports {
+        fmt.Printf("\n=== %s ===\n", r.Key)
+        if r.Err != nil {
+            fmt.Fprintln(os.Stderr, "stackfetch:", r.Err)
+            continue
+        }
+        fmt.Println(r.Info)
+        if depList := langfetch.Dependencies(r.Key); len(depList) > 0 {
+            fmt.Println("  └─ depends on:")
+            for _, d := range depList {
+                st := services.StatusByName(d)
+                printServiceLine(d, st)
+            }
+        }
+    }
+
+    return nil
+}
+
+func printServiceLine(name string, s services.Status) {
+	var line string
+	switch {
+	case !s.Installed:
+		line = color.RedString("✗ %s (not installed)", name)
+	case s.Running:
+		line = color.GreenString("✔ %s (running)", name)
+	default:
+		line = color.YellowString("! %s (installed, not running)", name)
 	}
-	for _, r := range res.Reports {
-		fmt.Printf("\n=== %s ===\n", r.Key)
-		if r.Err != nil {
-			fmt.Fprintln(os.Stderr, "stackfetch:", r.Err)
-			continue
-		}
-		fmt.Println(r.Info)
-	}
-	return nil
+	fmt.Println(line)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module github.com/sanix-darker/stackfetch
 go 1.20
 
 require (
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
@@ -15,5 +18,5 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/sys v0.25.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -6,6 +8,11 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -27,10 +34,14 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
+golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/langfetch/dependencies.go
+++ b/internal/langfetch/dependencies.go
@@ -1,0 +1,40 @@
+package langfetch
+
+import "strings"
+
+// depMap defines inter-item dependencies: if item X requires Y,Z before it.
+var depMap = map[string][]string{
+    // Web stacks
+    "lamp":  {"apache", "mysql", "php"},
+    "lemp":  {"nginx", "mysql", "php"},
+    "lapp":  {"apache", "postgresql", "php"},
+    "lnmp":  {"nginx", "mysql", "php"},
+    "mean":  {"mongodb", "node", "npm", "angular"},
+    "mern":  {"mongodb", "node", "npm", "yarn"},
+    "mevn":  {"mongodb", "node", "npm", "vue"},
+    "pern":  {"postgresql", "node", "npm", "react"},
+    "elk":   {"elasticsearch", "logstash", "kibana"},
+    "efk":   {"elasticsearch", "fluentd", "kibana"},
+    "jam":   {"node", "npm", "gatsby"},
+    "wamp":  {"apache", "mysql", "php"},
+    "xampp": {"apache", "mariadb", "php", "perl"},
+
+    // Other stacks
+    "tall":  {"tailwindcss", "alpinejs", "laravel", "livewire"},
+    "smack": {"spark", "mesos", "akka", "cassandra", "kafka"},
+    "tick":  {"telegraf", "influxdb", "chronograf", "kapacitor"},
+    "famp":  {"apachectl", "mysql", "php"},
+    "slad":  {"aws", "sam"},
+    "kstack": {"kubectl", "kustomize", "helm", "k3d"},
+    "dcp":   {"docker", "compose", "podman"},
+}
+
+// Dependencies returns the list of items a given key depends on.
+// It returns nil if there are no registered dependencies.
+func Dependencies(key string) []string {
+    key = strings.ToLower(key)
+    if deps, ok := depMap[key]; ok {
+        return deps
+    }
+    return nil
+}

--- a/internal/services/status.go
+++ b/internal/services/status.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+    "os/exec"
+    "runtime"
+    "strings"
+)
+
+// Status represents the installation and runtime state of a service or CLI tool.
+type Status struct {
+    Name      string // service or tool name
+    Installed bool   // executable found in PATH
+    Running   bool   // process/service is currently active
+}
+
+// Check inspects only the provided service/tool names.
+// It returns a slice of Status, one per requested name.
+func Check(names []string) []Status {
+    statuses := make([]Status, 0, len(names))
+    seen := map[string]struct{}{}
+
+    for _, raw := range names {
+        name := strings.ToLower(raw)
+        if _, dup := seen[name]; dup {
+            continue
+        }
+        seen[name] = struct{}{}
+        statuses = append(statuses, StatusByName(name))
+    }
+
+    return statuses
+}
+
+// StatusByName returns the Status for a single service/tool.
+func StatusByName(name string) Status {
+    s := Status{Name: name}
+
+    // Check installation
+    if _, err := exec.LookPath(name); err == nil {
+        s.Installed = true
+    }
+
+    // Check running state
+    switch runtime.GOOS {
+    case "linux", "darwin":
+        // pgrep -x matches exact process name
+        if err := exec.Command("pgrep", "-x", name).Run(); err == nil {
+            s.Running = true
+        }
+    case "windows":
+        // tasklist /FI filter
+        out, err := exec.Command("tasklist", "/FI", "IMAGENAME eq "+name+".exe").Output()
+        if err == nil && strings.Contains(string(out), name+".exe") {
+            s.Running = true
+        }
+    }
+
+    return s
+}

--- a/internal/services/status_test.go
+++ b/internal/services/status_test.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+    "testing"
+)
+
+func TestCheck(t *testing.T) {
+    // Assuming 'go' is always installed; test Check() picks it up
+    statuses := Check([]string{"go", "go"}) // duplicate should be skipped
+    if len(statuses) != 1 {
+        t.Fatalf("expected 1 status entry, got %d", len(statuses))
+    }
+    if !statuses[0].Installed {
+        t.Errorf("expected 'go' to be reported as installed")
+    }
+}
+
+func TestStatusByName(t *testing.T) {
+    s := StatusByName("this-does-not-exist-xyz")
+    if s.Installed || s.Running {
+        t.Errorf("expected non-existent binary to report Installed=false, Running=false")
+    }
+}


### PR DESCRIPTION
## WHAT

- Add service checks (on status, installed or not)
- Add colors regarding services and dependencies

```
$ stackfetch lamp
=== System ===
OS: ubuntu 20.04
Arch: amd64
CPUs: 8
Kernel: 5.15.0-136-generic
Hostname: zx
Uptime: 6d 12h
VM: kvm (host)

=== lamp ===
LAMP
Apache: Server version: Apache/2.4.41 (Ubuntu)
Server built:   2025-04-02T18:34:29
MySQL: mysql  Ver 8.0.41-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))
PHP: PHP 8.3.20 (cli) (built: Apr 10 2025 21:33:00) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.3.20, Copyright (c) Zend Technologies
    with Zend OPcache v8.3.20, Copyright (c), by Zend Technologies
    with Xdebug v3.4.2, Copyright (c) 2002-2025, by Derick Rethans
  └─ depends on:
✗ apache (not installed)
! mysql (installed, not running)
! php (installed, not running)
```
